### PR TITLE
fix: expose TypeScript types in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./dist/bundle.js",
-      "import": "./dist/bundle.mjs"
+      "import": "./dist/bundle.mjs",
+      "types": "./dist/bundle.d.ts"
     }
   },
   "main": "dist/bundle.js",


### PR DESCRIPTION
TypeScript requires "types" to be explicitly defined in the "exports" field when it is present, otherwise type declarations like `bundle.d.ts` are ignored.

This change ensures consumers can use `@omp-node/core` without TS7016 errors when using ESM and modern TypeScript resolution.

See: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports